### PR TITLE
set `Response` to public to extend possibilities for request abstractions

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -39,7 +39,7 @@ pub const Error = struct {
 /// of one or the other but not both
 ///
 /// See the [GraphQL docs](https://graphql.org/learn/serving-over-http/#response) for more information
-fn Response(comptime T: type) type {
+pub fn Response(comptime T: type) type {
     return struct {
         errors: ?[]Error = null,
         data: ?T = null,


### PR DESCRIPTION
Currently it's not possible to return the response from a function due to private due to the visibility of `Response` set to private.

The PR would set it to public to extend possibilities for organizing code.

```zig
fn myRequest(...) !graphql.Owned(graphql.Response(Foo)) {
	const resp = try client.send(.{
		...
	}, Foo);
	...
	return resp;
}

pub fn main() !void {
	try myRequest();
	...	
}
```

Ofc. there might be good reasons why it is intentionally private which I didn't spot from shortly looking into the Code and I might miss context due to little time using the library.