### PR TITLE
Bump Zig to 0.14.1 and update project definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.1
       - name: fmt
         run: zig fmt --check .
   examples:
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.1
       - name: run
         run: zig build run-github-example
   test:
@@ -38,6 +38,6 @@ jobs:
         uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.1
       - name: Test
         run: zig build test --summary all

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 # https://github.com/asdf-community/asdf-zig
-zig 0.13.0
+zig 0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+Upgrade to zig 0.14.1, current stable. Changes in the project definition (`build.zig.zon`) are incompatible with the previous version, resulting in a version bump from 0.2.2 to 0.3.0.
+
 # 0.2.2
 
 Upgrade to zig 0.13.0, current stable. No breaking changes.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-[![ci](https://github.com/softprops/zig-graphql/actions/workflows/ci.yml/badge.svg)](https://github.com/softprops/zig-graphql/actions/workflows/ci.yml) ![License Info](https://img.shields.io/github/license/softprops/zig-graphql) ![Releases](https://img.shields.io/github/v/release/softprops/zig-graphql) [![Zig Support](https://img.shields.io/badge/zig-0.13.0-black?logo=zig)](https://ziglang.org/documentation/0.13.0/)
+[![ci](https://github.com/softprops/zig-graphql/actions/workflows/ci.yml/badge.svg)](https://github.com/softprops/zig-graphql/actions/workflows/ci.yml) ![License Info](https://img.shields.io/github/license/softprops/zig-graphql) ![Releases](https://img.shields.io/github/v/release/softprops/zig-graphql) [![Zig Support](https://img.shields.io/badge/zig-0.14.1-black?logo=zig)](https://ziglang.org/documentation/0.14.1/)
 
 ## examples
 
@@ -115,7 +115,7 @@ to manually add it as follows
         // 👇 declare dep properties
         .graphql = .{
             // 👇 uri to download
-            .url = "https://github.com/softprops/zig-graphql/archive/refs/tags/v0.2.2.tar.gz",
+            .url = "https://github.com/softprops/zig-graphql/archive/refs/tags/v0.3.0.tar.gz",
             // 👇 hash verification
             .hash = "{current-hash-here}",
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,14 @@
 .{
-    .name = "graphql",
-    .version = "0.2.2",
-    .minimum_zig_version = "0.13.0",
-    .paths = .{""},
+    .name = .graphql,
+    .version = "0.3.0",
+    .minimum_zig_version = "0.14.0",
+    .fingerprint = 0x6e1e00e2ddccb72b,
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "examples",
+        "LICENSE",
+        "README.md",
+    },
 }


### PR DESCRIPTION
The new build.zig.zon format is incompatible with previous versions, necessitating a project version bump to 0.3.0.