### PR TITLE
Split send to allow raw body and parsed res

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.1
       - name: fmt
         run: zig fmt --check .
   examples:
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.1
       - name: run
         run: zig build run-github-example
   test:
@@ -38,6 +38,6 @@ jobs:
         uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.1
       - name: Test
         run: zig build test --summary all

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 # https://github.com/asdf-community/asdf-zig
-zig 0.13.0
+zig 0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0
+
+The `send` function is now designed to return the raw body. A new function, `splitAndParse`, has been added to perform the previous `send` operation. Due to incompatible API changes, the version has been bumped from 0.3.0 to 0.4.0.
+
 # 0.3.0
 
 Upgrade to zig 0.14.1, current stable. Changes in the project definition (`build.zig.zon`) are incompatible with the previous version, resulting in a version bump from 0.2.2 to 0.3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+Upgrade to zig 0.14.1, current stable. Changes in the project definition (`build.zig.zon`) are incompatible with the previous version, resulting in a version bump from 0.2.2 to 0.3.0.
+
 # 0.2.2
 
 Upgrade to zig 0.13.0, current stable. No breaking changes.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Create a `build.zig.zon` file to declare a dependency
 Starting in zig `0.12.0`, you can use
 
 ```sh
-zig fetch --save https://github.com/softprops/zig-graphql/archive/refs/tags/v0.2.2.tar.gz
+zig fetch --save https://github.com/softprops/zig-graphql/archive/refs/tags/v0.4.0.tar.gz
 ```
 
 to manually add it as follows
@@ -115,7 +115,7 @@ to manually add it as follows
         // 👇 declare dep properties
         .graphql = .{
             // 👇 uri to download
-            .url = "https://github.com/softprops/zig-graphql/archive/refs/tags/v0.3.0.tar.gz",
+            .url = "https://github.com/softprops/zig-graphql/archive/refs/tags/v0.4.0.tar.gz",
             // 👇 hash verification
             .hash = "{current-hash-here}",
         },

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-[![ci](https://github.com/softprops/zig-graphql/actions/workflows/ci.yml/badge.svg)](https://github.com/softprops/zig-graphql/actions/workflows/ci.yml) ![License Info](https://img.shields.io/github/license/softprops/zig-graphql) ![Releases](https://img.shields.io/github/v/release/softprops/zig-graphql) [![Zig Support](https://img.shields.io/badge/zig-0.13.0-black?logo=zig)](https://ziglang.org/documentation/0.13.0/)
+[![ci](https://github.com/softprops/zig-graphql/actions/workflows/ci.yml/badge.svg)](https://github.com/softprops/zig-graphql/actions/workflows/ci.yml) ![License Info](https://img.shields.io/github/license/softprops/zig-graphql) ![Releases](https://img.shields.io/github/v/release/softprops/zig-graphql) [![Zig Support](https://img.shields.io/badge/zig-0.14.1-black?logo=zig)](https://ziglang.org/documentation/0.14.1/)
 
 ## examples
 
@@ -115,7 +115,7 @@ to manually add it as follows
         // 👇 declare dep properties
         .graphql = .{
             // 👇 uri to download
-            .url = "https://github.com/softprops/zig-graphql/archive/refs/tags/v0.2.2.tar.gz",
+            .url = "https://github.com/softprops/zig-graphql/archive/refs/tags/v0.3.0.tar.gz",
             // 👇 hash verification
             .hash = "{current-hash-here}",
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .graphql,
-    .version = "0.3.0",
+    .version = "0.4.0",
     .minimum_zig_version = "0.14.0",
     .fingerprint = 0x6e1e00e2ddccb72b,
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,14 @@
 .{
-    .name = "graphql",
-    .version = "0.2.2",
-    .minimum_zig_version = "0.13.0",
-    .paths = .{""},
+    .name = .graphql,
+    .version = "0.3.0",
+    .minimum_zig_version = "0.14.0",
+    .fingerprint = 0x6e1e00e2ddccb72b,
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "examples",
+        "LICENSE",
+        "README.md",
+    },
 }

--- a/examples/github/main.zig
+++ b/examples/github/main.zig
@@ -33,7 +33,7 @@ pub fn main() !void {
     );
     defer github.deinit();
 
-    const result = github.send(
+    const result = github.sendAndParse(
         .{
             .query =
             \\query test {

--- a/src/main.zig
+++ b/src/main.zig
@@ -138,14 +138,27 @@ pub const Client = struct {
         self.httpClient.deinit();
     }
 
-    /// Sends a GraphQL Request to a server
+    /// Sends a GraphQL Request to a server and parses the response
     ///
     /// Callers are expected to call `deinit()` on the Owned type returned to free memory.
-    pub fn send(
+    pub fn sendAndParse(
         self: *Self,
         request: Request,
         comptime T: type,
     ) RequestError!Owned(Response(T)) {
+        const body = try self.send(request);
+        defer self.allocator.free(body);
+        const parsed = parseResponse(self.allocator, body, T) catch return error.Deserialization; // This line invokes parseResponse within sendAndParse
+        return Owned(Response(T)).fromJson(parsed);
+    }
+
+    /// Sends a GraphQL Request to a server without parsing the response
+    ///
+    /// Callers are expected to call `alloc.free(body)` on the owned slice returned to free memory.
+    pub fn send(
+        self: *Self,
+        request: Request,
+    ) RequestError![]const u8 {
         const headers = std.http.Client.Request.Headers{
             .content_type = .{ .override = "application/json" },
             .authorization = if (self.options.authorization) |authz| .{
@@ -186,9 +199,7 @@ pub const Client = struct {
                     self.allocator,
                     8192 * 2 * 2, // note: optimistic arb choice of buffer size
                 ) catch unreachable;
-                defer self.allocator.free(body);
-                const parsed = parseResponse(self.allocator, body, T) catch return error.Deserialization;
-                return Owned(Response(T)).fromJson(parsed);
+                return body;
             },
         }
     }


### PR DESCRIPTION
This may be useful in cases where more control over the incoming data is needed.